### PR TITLE
兼容webpack4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,9 @@
 {
-  "name": "unused-webpack-plugin",
-  "version": "1.0.0",
+  "name": "@mokahr/unused-webpack-plugin",
+  "version": "1.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@types/anymatch": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npm.taobao.org/@types/anymatch/download/@types/anymatch-1.3.1.tgz",
-      "integrity": "sha1-M2utwb7sudrMOL6izzKt9ieoQho=",
-      "dev": true
-    },
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npm.taobao.org/@types/events/download/@types/events-3.0.0.tgz?cache=0&sync_timestamp=1572461479213&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40types%2Fevents%2Fdownload%2F%40types%2Fevents-3.0.0.tgz",
@@ -38,52 +32,6 @@
       "resolved": "https://registry.npm.taobao.org/@types/node/download/@types/node-13.1.0.tgz",
       "integrity": "sha1-Ily6rF/bK5rGUbAsBw2Ko8N8yBI=",
       "dev": true
-    },
-    "@types/source-list-map": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npm.taobao.org/@types/source-list-map/download/@types/source-list-map-0.1.2.tgz",
-      "integrity": "sha1-AHiDYGP/rxdBI0m7o2QIfgrALsk=",
-      "dev": true
-    },
-    "@types/tapable": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npm.taobao.org/@types/tapable/download/@types/tapable-1.0.4.tgz",
-      "integrity": "sha1-tP/H3Je0mMlps2CkHu4kf4JhY3A=",
-      "dev": true
-    },
-    "@types/uglify-js": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npm.taobao.org/@types/uglify-js/download/@types/uglify-js-3.0.4.tgz",
-      "integrity": "sha1-lr6uI99vVhhiqDC0KIpJ6GuqwII=",
-      "dev": true,
-      "requires": {
-        "source-map": "^0.6.1"
-      }
-    },
-    "@types/webpack": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npm.taobao.org/@types/webpack/download/@types/webpack-4.41.0.tgz?cache=0&sync_timestamp=1573938343658&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40types%2Fwebpack%2Fdownload%2F%40types%2Fwebpack-4.41.0.tgz",
-      "integrity": "sha1-uBOgRNiw3sffzXYi/b4ye94G65o=",
-      "dev": true,
-      "requires": {
-        "@types/anymatch": "*",
-        "@types/node": "*",
-        "@types/tapable": "*",
-        "@types/uglify-js": "*",
-        "@types/webpack-sources": "*",
-        "source-map": "^0.6.0"
-      }
-    },
-    "@types/webpack-sources": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npm.taobao.org/@types/webpack-sources/download/@types/webpack-sources-0.1.5.tgz",
-      "integrity": "sha1-vkfBD3g9PW7+FHH/fwQmEb1GSpI=",
-      "dev": true,
-      "requires": {
-        "@types/node": "*",
-        "@types/source-list-map": "*",
-        "source-map": "^0.6.1"
-      }
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -157,10 +105,10 @@
       "resolved": "https://registry.npm.taobao.org/path-is-absolute/download/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
-    "source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsource-map%2Fdownload%2Fsource-map-0.6.1.tgz",
-      "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+    "typescript": {
+      "version": "3.7.4",
+      "resolved": "https://registry.npm.taobao.org/typescript/download/typescript-3.7.4.tgz",
+      "integrity": "sha1-F0Ol7F/vah+p8+RwjjPIHHOHbBk=",
       "dev": true
     },
     "wrappy": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "@types/glob": "^7.1.1",
-    "@types/node": "^13.1.0"
+    "@types/node": "^13.1.0",
+    "typescript": "^3.7.4"
   }
 }

--- a/release.sh
+++ b/release.sh
@@ -25,7 +25,7 @@ fi
 
 # build source files
 rm -Rf dist/*
-tsc
+./node_modules/.bin/tsc
 
 # publish master branch
 cp package.json dist/

--- a/src/UnusedWebpackPlugin.ts
+++ b/src/UnusedWebpackPlugin.ts
@@ -6,28 +6,28 @@ interface Options {
    * Current working directory
    * @defaultValue ./
    */
-  cwd: string;
+  cwd?: string;
   /**
    * Included patterns
    * @defaultValue ['**\/*.js', '**\/*.styl']
    */
-  patterns: string[];
+  patterns?: string[];
   /**
    * Excluded patterns
    * @defaultValue ['node_modules/**']
    */
-  ignores: string[];
+  ignores?: string[];
   /**
    * The output unused files list path
    * @defaultValue ./unused-files
    */
-  output: string;
+  output?: string;
 }
 
 class UnusedWebpackPlugin {
   options: Options;
   constructor(options: Options) {
-    this.options = options || { cwd: '', patterns: [], ignores: [], output: '' };
+    this.options = options || {};
     this.options.cwd = this.options.cwd || './';
     this.options.patterns = this.options.patterns || ['**/*.js', '**/*.styl'];
     this.options.ignores = (this.options.ignores || []).concat('node_modules/**');
@@ -39,11 +39,11 @@ class UnusedWebpackPlugin {
   apply(compiler: any) {
     compiler.plugin('after-compile', (compilation: any, callback: any) => {
       const localDependencies = new Set();
-      for (const dependency of compilation.fileDependencies) {
+      compilation.fileDependencies.forEach((dependency: string) => {
         if (!/node_modules/.test(dependency)) {
           localDependencies.add(dependency);
         }
-      }
+      });
 
       Promise.all(this.options.patterns.map((pattern) => {
         return new Promise((resolve, reject) => {


### PR DESCRIPTION
-  增加ts依赖, 因为可能本地没全局安装过ts, 或者是版本过低导致编译错误. 并且更新了release对应的脚本代码
- 修改compilation.fileDependencies的遍历方式. ts会吧`for of`转义成普通的for循环, webpack4的`compilation.fileDependencies`是一个set, 没有`length`, 导致拿不到依赖文件列表.现在改用`forEach`来遍历
- 修改了option的默认值, 之前如果不传options, 则插件无法正常工作, 默认值没能正确的赋值